### PR TITLE
debug build [URO-70]

### DIFF
--- a/.github/workflows/build-release-dist.yml
+++ b/.github/workflows/build-release-dist.yml
@@ -21,7 +21,7 @@ jobs:
       # Add the built assets to the release
       #
       - name: Upload dist to release
-        uses: alexellis/upload-assets@0.2.2
+        uses: alexellis/upload-assets@0.4.0
         env:
           # GITHUB_TOKEN: ${{ secrets.KBASE_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-release-dist.yml
+++ b/.github/workflows/build-release-dist.yml
@@ -24,6 +24,7 @@ jobs:
         uses: alexellis/upload-assets@0.4.0
         env:
           # GITHUB_TOKEN: ${{ secrets.KBASE_BOT_TOKEN }}
+          ACTIONS_STEP_DEBUG: true
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["dist.tgz"]'


### PR DESCRIPTION
for some reason, the asset is not being uploaded to the release. 
so I'm making some changes to the upload-assets action - updating to the latest version, adding debug flag
but now I see that the release is not appearing in the releases page, even though there are other ways of navigating to it.
so I managed to delete the release and tag, and will try again; I suspect a glitch at Github, as the package builds the dist just fine.